### PR TITLE
Ability to create multiple accessories for each Zone on the Yamaha Receiver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for th
 config.json
 
 "manual_addresses" only needed if Bonjour/Autodetection doesn't work.
+"zones_as_accessories" only needed if you have multiple speaker zones that you want to be exposed as seperate accessories to HomeKit.
 
 Example:
 
@@ -28,9 +29,19 @@ Example:
         {
             "platform": "YamahaAVR",
             "play_volume": -48,
-            "setMainInputTo": "Airplay",
+            "set_input_to": "Airplay",
             "manual_addresses": {
                 "Yamaha": "192.168.1.115"
+            },
+            "zones_as_accessories": {
+                "Yamaha": {
+                    "1": {
+                        "name":"Main"
+                    },
+                    "2": {
+                        "name":"Zone 2"
+                    }
+                }
             }
         }
     ],

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for th
 config.json
 
 "manual_addresses" only needed if Bonjour/Autodetection doesn't work.
+
 "zones_as_accessories" only needed if you have multiple speaker zones that you want to be exposed as seperate accessories to HomeKit.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ homebridge-plugin for Yamaha AVR control with Apple-Homekit.
 
 # Installation
 Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for the homebridge server installation. The plugin is published through [NPM](https://www.npmjs.com/package/homebridge-yamaha) and should be installed "globally" by typing:
-
+    ```
     sudo npm install -g homebridge-yamaha
-
-#Configuration
+    ```
+# Configuration
 
 config.json
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@ homebridge-plugin for Yamaha AVR control with Apple-Homekit.
 
 # Installation
 Follow the instruction in [NPM](https://www.npmjs.com/package/homebridge) for the homebridge server installation. The plugin is published through [NPM](https://www.npmjs.com/package/homebridge-yamaha) and should be installed "globally" by typing:
-    ```
-    sudo npm install -g homebridge-yamaha
-    ```
+
+```
+sudo npm install -g homebridge-yamaha
+```
+
 # Configuration
 
-config.json
+## config.json
 
-"manual_addresses" only needed if Bonjour/Autodetection doesn't work.
+`"manual_addresses"` only needed if Bonjour/Autodetection doesn't work.
 
-"zones_as_accessories" only needed if you have multiple speaker zones that you want to be exposed as seperate accessories to HomeKit.
+`"zones_as_accessories"` only needed if you have multiple speaker zones that you want to be exposed as seperate accessories to HomeKit.
 
 Example:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-yamaha",
-  "version": "0.0.5-alpha.1",
+  "version": "0.0.5-alpha.2",
   "description": "homebridge-plugin for Yamaha AVR https://github.com/nfarina/homebridge",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "dependencies": {
     "inherits": "^2.0.1",
     "request": "2.65.x",
-    "yamaha-nodejs": "0.4.x",
+    "yamaha-nodejs": "0.6.x",
     "mdns": "^2.2.4",
     "q": "1.4.x",
     "debug": "^2.2.0",


### PR DESCRIPTION
This change allows the plug-in to create multiple accessories for each of the speaker zones on the receiver.

The zones must be specified in a new 'zones_as_accessories' key in the config.   I renamed the 'SetMainInputTo' key to 'set_input_to' as it can now apply to multiple zones, however the old key name is backward compatible.